### PR TITLE
#2 Fix HTTP module error while trying to write header

### DIFF
--- a/src/portals/admin.coffee
+++ b/src/portals/admin.coffee
@@ -6,6 +6,7 @@ path = require 'path'
 status = new ns.Server (path.resolve __dirname, '../../webroot')
 
 module.exports.Admin = class Admin extends Portal
+
    constructor : (endpoints) ->
       @endpoints = endpoints
       @contract = contract
@@ -14,7 +15,7 @@ module.exports.Admin = class Admin extends Portal
    urlPattern : /^\/([1-9][0-9]*)?$/
 
    goPong: (response) ->
-      response.writeHead 200, {'Content-Type' : 'text/plain'}
+      @writeHead response, 200, {'Content-Type' : 'text/plain'}
       response.end 'pong'
 
    goPUT : (request, response) ->
@@ -92,14 +93,14 @@ module.exports.Admin = class Admin extends Portal
       @endpoints.create data, callback
 
    ok : (response, result) ->
-      response.writeHead 200, {'Content-Type' : 'application/json'}
+      @writeHead response, 200, {'Content-Type' : 'application/json'}
       if result?
          response.end(JSON.stringify result)
       else
          response.end()
 
    created : (response, request, id) ->
-      response.writeHead 201, {'Location' : "#{request.headers.host}/#{id}"}
+      @writeHead response, 201, {'Location' : "#{request.headers.host}/#{id}"}
       response.end()
 
    noContent : (response) ->
@@ -107,7 +108,7 @@ module.exports.Admin = class Admin extends Portal
       response.end()
 
    badRequest : (response, errors) ->
-      response.writeHead 400, {'Content-Type' : 'application/json'}
+      @writeHead response, 400, {'Content-Type' : 'application/json'}
       response.end JSON.stringify errors
 
    notSupported : (response) ->
@@ -115,15 +116,15 @@ module.exports.Admin = class Admin extends Portal
       response.end()
 
    notFound : (response) ->
-      response.writeHead 404, {'Content-Type' : 'text/plain'}
+      @writeHead response, 404, {'Content-Type' : 'text/plain'}
       response.end()
 
    saveError : (response) ->
-      response.writeHead 422, {'Content-Type' : 'text/plain'}
+      @writeHead response, 422, {'Content-Type' : 'text/plain'}
       response.end()
 
    serverError : (response) ->
-      response.writeHead 500, {'Content-Type' : 'text/plain'}
+      @writeHead response, 500, {'Content-Type' : 'text/plain'}
       response.end()
 
    urlValid : (url) ->

--- a/src/portals/portal.coffee
+++ b/src/portals/portal.coffee
@@ -6,6 +6,10 @@ module.exports.Portal = class Portal
    constructor: ->
       @name = 'portal'
 
+   writeHead: (response, status_code, headers) ->
+      response.writeHead status_code, headers if !response.headersSent
+      return response
+
    received: (request, response) ->
       date = new Date()
       hours = "0#{date.getHours()}".slice -2

--- a/src/portals/stubs.coffee
+++ b/src/portals/stubs.coffee
@@ -23,10 +23,10 @@ module.exports.Stubs = class Stubs extends Portal
 
          callback = (err, endpointResponse) =>
             if err
-               response.writeHead 404, {}
+               @writeHead response, 404, {}
                @responded 404, request.url, 'is not a registered endpoint'
             else
-               response.writeHead endpointResponse.status, endpointResponse.headers
+               @writeHead response, endpointResponse.status, endpointResponse.headers
                response.write endpointResponse.body
 
                @responded endpointResponse.status, request.url


### PR DESCRIPTION
Fixes the issue #2

Maybe it's not the best way to solve it, but I didn't make a deep review of the code.

According with your OO design, I created a public method called `writeHead` in the `Portal` parent class in order to verify if the response head was already written. This method are used from `Admin` and `Stubs` classes.

Hope it can be merged as soon as possible.

Thank you so much for the amazing work you done!!
Cheers
