### PR TITLE
Token replacement now replaces all instances

### DIFF
--- a/src/models/endpoints.coffee
+++ b/src/models/endpoints.coffee
@@ -67,7 +67,7 @@ module.exports.Endpoints = class Endpoints
 applyTemplating = (obj, captures) ->
   for key, value of obj
     if typeof value is 'string' or value instanceof Buffer
-      obj[key] = ejs.render value.toString().replace('<%', '<%='), captures
+      obj[key] = ejs.render value.toString().replace(/<%/g, '<%='), captures
     else
       applyTemplating value, captures
 


### PR DESCRIPTION
Was previously only replacing the first instance of a dynamic token eg. `<% url[1] %>`
