### PR TITLE
Fix an issue with identical URLs for GET and POST

### DIFF
--- a/src/models/endpoint.coffee
+++ b/src/models/endpoint.coffee
@@ -22,7 +22,7 @@ module.exports = class Endpoint
     if @request.file?
       try file = fs.readFileSync path.resolve(@datadir, @request.file), 'utf8'
 
-    if post = file or @request.post
+    if (post = file or @request.post) and request.post
       return null unless matches.post = matchRegex normalizeEOL(post), normalizeEOL(request.post)
 
     if @request.method instanceof Array


### PR DESCRIPTION
If you have two endpoints with identical URLs, but one was a GET
and one was a POST, you would get a 500 error when doing a
GET against the URL.

The problem was passing `request.post` to `normalizeEOL`, which
expects a string. When doing a GET, `request.post` is null,
causing an exception.
