### PR TITLE
Exit gracefully with the location printed to the console

### DIFF
--- a/src/main.coffee
+++ b/src/main.coffee
@@ -22,7 +22,7 @@ onError = (err, port, location) ->
       when 'EADDRINUSE'
          msg = "Port #{port} is already in use! Exiting..."
       when 'EADDRNOTAVAIL'
-         msg = "Host \"#{options.location}\" is not available! Exiting..."
+         msg = "Host \"#{location}\" is not available! Exiting..."
 
    out.error msg
    console.dir err


### PR DESCRIPTION
Currently, an error occurs when you specify an address that is not
available to be stubbed out with the -l flag (example: google.com). The
'options' variable isn't available within the onError function. The fix
is to just reference location directly since it's being passed in
anyway.

Bug introduced in 9df823d8a6f7cc851f825f7d8bd01458f36dc051
