### PR TITLE
Function refresh was being called without reference to this

### DIFF
--- a/lib/console/watch.js
+++ b/lib/console/watch.js
@@ -31,7 +31,7 @@ Watcher.prototype.activate = function() {
 
   watching = true;
   out.status('Watching for changes in ' + this.filename + '...');
-  intervalId = setInterval(this.refresh, interval);
+  intervalId = setInterval(this.refresh.bind(this), interval);
 };
 
 Watcher.prototype.refresh = function() {


### PR DESCRIPTION
When data filename is supplied on `options.watch` stubby is crashing:

````
fs.js:439
  return binding.open(pathModule._makeLong(path), stringToFlags(flags), mode);
                 ^
TypeError: path must be a string
    at Object.fs.openSync (fs.js:439:18)
    at Object.fs.readFileSync (fs.js:290:15)
    at Watcher.refresh (/Users/diegosilveira/development/zup/cockpit/cockpit-gateway/node_modules/stubby/lib/console/watch.js:40:17)
    at wrapper [as _onTimeout] (timers.js:261:14)
    at Timer.listOnTimeout [as ontimeout] (timers.js:112:15)
```

This is because function `Watcher.refresh`was being called unbound on `setInterval`, and so `this.filename` is `undefined`.