### PR TITLE
Handle array parameters in query

### DIFF
--- a/src/models/endpoint.js
+++ b/src/models/endpoint.js
@@ -208,7 +208,7 @@ function compareHashMaps(configured, incoming) {
 
 function matchRegex(compileMe, testMe) {
   if (testMe == null) { testMe = ''; }
-  return testMe.match(RegExp(compileMe, 'm'));
+  return String(testMe).match(RegExp(compileMe, 'm'));
 }
 
 module.exports = Endpoint;


### PR DESCRIPTION
Hi,

I wanted to match on query parameters that are arrays (like http://example.com/?arrayParam=1&arrayParam=2) but discovered that stubby doesn't correctly handle this : it just seems to fail silently in the matchRegex function since arrays don't have the `.match()` function.
Simply casting the `testMe` to a String seems to do the trick without ill effects. The example above would become the string `"1,2"`, which we can run a regex against.

Cheers