### PR TITLE
fix(stubby): Check for undefined callback first

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -86,13 +86,13 @@ function Stubby() {
 }
 
 Stubby.prototype.start = function (o, cb) {
-  var oc = setupStartOptions(o, cb);
+  var _o = o == null ? {} : o;
+  var _cb = cb == null ? noop : cb;
+
+  var oc = setupStartOptions(_o, _cb);
   var options = oc[0];
   var callback = oc[1];
   var self = this;
-
-  if (o == null) { o = {}; }
-  if (cb == null) { cb = noop; }
 
   this.stop(function () {
     var errors = contract(options.data);

--- a/test/main.js
+++ b/test/main.js
@@ -128,6 +128,11 @@ describe('main', function () {
     });
 
     describe('callback', function () {
+      it('should not fail to start a server without options or a callback', function (done) {
+        sut.start();
+        done();
+      });
+
       it('should treat the callback as optional', function (done) {
         var callback = this.sandbox.spy();
 


### PR DESCRIPTION
If you try and start stubby without setting the callback to noop
before assigning startup options, you'll get "undefined is not a function"
on the last line of `Stubby.prototype.start`.