### PR TITLE
Fixed Bearer token being converted to base64 (Fixes #50)

### DIFF
--- a/src/models/endpoint.js
+++ b/src/models/endpoint.js
@@ -161,7 +161,7 @@ function purifyAuthorization(headers) {
   if (headers == null || headers.authorization == null) { return headers; }
 
   auth = headers.authorization || '';
-  if (!/:/.test(auth)) { return headers; }
+  if (!/:/.test(auth) || /Bearer: /.test(auth)) { return headers; }
 
   headers.authorization = 'Basic ' + new Buffer(auth).toString('base64');
   return headers;

--- a/test/endpoint.js
+++ b/test/endpoint.js
@@ -312,6 +312,18 @@ describe('Endpoint', function () {
       assert(actual.request.headers.authorization === expected);
     });
 
+    it('should not encode authorization headers if bearer token', function () {
+      var actual, expected;
+      expected = 'Bearer: MY_TOKEN_123';
+      this.data.request.headers = {
+        authorization: 'Bearer: MY_TOKEN_123'
+      };
+
+      actual = new Endpoint(this.data);
+
+      assert(actual.request.headers.authorization === expected);
+    });
+
     it('should stringify object body in response', function () {
       var actual, expected;
       expected = '{"property":"value"}';


### PR DESCRIPTION
fixes #50 
This allows matching on the `Bearer` Authorization header, which was previously broken, due to the code always converting it to base64 encoded, if a `:` was found in the header.

I'm not clued up on all the possible options for the Authorization header, so I've left this as an exception for the Bearer token only. I'll be happy to extend it more generically, if anyone has a full list.