### PR TITLE
Simple docker support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM node:latest
+
+WORKDIR /stubby
+COPY package.json /stubby
+
+RUN npm i
+
+COPY . /stubby
+
+EXPOSE 7443 8882 8889
+CMD npm start

--- a/README.md
+++ b/README.md
@@ -25,6 +25,11 @@ A configurable server for mocking/stubbing external systems during development.
 
 ## Installation
 
+### via docker
+
+    docker build -t stubby .
+    docker run -d -P stubby
+
 ### via npm
 
     npm install -g stubby

--- a/bin/stubby.js
+++ b/bin/stubby.js
@@ -1,5 +1,3 @@
-#!/usr/bin/env node
-
 var CLI = require('../src/console/cli');
 var stubby = new (require('../src/main').Stubby);
 var options = CLI.getArgs();

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   "scripts": {
     "lint": "semistandard",
     "test": "npm run lint && mocha --recursive test --reporter dot",
-    "start": "bin/stubby"
+    "start": "node bin/stubby.js"
   },
   "bin": {
     "stubby": "bin/stubby"


### PR DESCRIPTION
This can fit into the existing pipeline and be deployed to dockerhub for public use. Someone could then simply run `docker run -d -P stubby` and it will pull the public image.

We are going to use this for an internal project and might end up moving a few of the files around so we don't include the tests in the docker image. But as an initial pass it's the right way to go I think 👍 
