### PR TITLE
Clarify use of interpolated file responses

### DIFF
--- a/README.md
+++ b/README.md
@@ -403,7 +403,7 @@ The `response.body` can have token interpolations following the format of `< %PR
 ```
 
 __NOTE:__ If you are using the `file` property for your responses, keep in mind that the
-file _contents_ are interpolated, not the file _name_. In other words, the `<% ... %>` will appear in the files' contents and not on the line in your configuration that has `response.file`
+both the file _name_ and _contents_ are interpolated. In other words, the `<% ... %>` will appear in the files' contents as well as on the line in your configuration that has `response.file`
 
 ### Capture group IDs
 

--- a/test/data/e2e.yaml
+++ b/test/data/e2e.yaml
@@ -87,7 +87,10 @@
     latency: 2000
     body: "updated"
 
-
+- request:
+    url: /file/dynamic/(.+)
+  response:
+    file: test/data/endpoints-<% url[1] %>.file
 
 - request:
     url: /file/body/missingfile

--- a/test/data/endpoints-1.file
+++ b/test/data/endpoints-1.file
@@ -1,0 +1,1 @@
+endpoints-1.file

--- a/test/data/endpoints-2.file
+++ b/test/data/endpoints-2.file
@@ -1,0 +1,1 @@
+endpoints-<% url[1] %>.file

--- a/test/e2e.stubs.js
+++ b/test/e2e.stubs.js
@@ -289,6 +289,24 @@ describe('End 2 End Stubs Test Suite', function () {
 
   describe('file use', function () {
     describe('response', function () {
+      it('should handle file name interpolation', function (done) {
+        this.context.url = '/file/dynamic/1';
+
+        createRequest(this.context, function (response) {
+          assert.strictEqual(response.data.trim(), 'endpoints-1.file');
+          done();
+        });
+      });
+
+      it('should handle file content interpolation', function (done) {
+        this.context.url = '/file/dynamic/2';
+
+        createRequest(this.context, function (response) {
+          assert.strictEqual(response.data.trim(), 'endpoints-2.file');
+          done();
+        });
+      });
+
       it('should handle fallback to body if specified response file cannot be found', function (done) {
         this.context.url = '/file/body/missingfile';
 


### PR DESCRIPTION
The current documentation states that file responses cannot be defined using interpolated names.  This is not actually the case.  I have written test cases to prove how this can be achieved, and updated the wording of the documentation.