### PR TITLE
Exit status 1 when stubby binary fails

### DIFF
--- a/bin/stubby
+++ b/bin/stubby
@@ -4,7 +4,13 @@ var CLI = require('../src/console/cli');
 var stubby = new (require('../src/main').Stubby);
 var options = CLI.getArgs();
 
-stubby.start(options);
+stubby.start(options, function(errors) {
+  if(Array.isArray(errors)) {
+    console.log('Stubby is being stopped because of errors:'); 
+    console.log(errors);
+    process.exit(1);
+  }
+});
 
 process.on('SIGHUP', function() {
   stubby.delete(function () { stubby.start(options); });

--- a/bin/stubby
+++ b/bin/stubby
@@ -7,7 +7,7 @@ var options = CLI.getArgs();
 stubby.start(options, function(errors) {
   if(Array.isArray(errors)) {
     console.log('Stubby is being stopped because of errors:'); 
-    console.log(errors);
+    errors.map(console.log);
     process.exit(1);
   }
 });


### PR DESCRIPTION
When stubby fails it should be also exposed to bash scripts so they can do actions in case there's an error. So exit status should be 1.

Also printing the message make it easier to users to debug what wen't wrong.

The message format is not the best, I would like input on that.