### PR TITLE
Delete all stubs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 node_modules
 npm-debug.log
 data/*
+.idea
+yarn.lock

--- a/src/main.js
+++ b/src/main.js
@@ -186,9 +186,7 @@ Stubby.prototype.delete = function (id, callback) {
 
   setTimeout(function () {
     if (typeof id === 'function') {
-      delete self.endpoints.db;
-      self.endpoints.db = {};
-      callback();
+      self.endpoints.deleteAll(callback);
     } else {
       self.endpoints.delete(id, callback);
     }

--- a/src/models/endpoints.js
+++ b/src/models/endpoints.js
@@ -71,6 +71,15 @@ Endpoints.prototype.delete = function (id, callback) {
   callback();
 };
 
+Endpoints.prototype.deleteAll = function (callback) {
+  if (callback == null) { callback = noop; }
+
+  delete this.db;
+  this.db = {};
+
+  callback();
+};
+
 Endpoints.prototype.gather = function (callback) {
   var id;
   var all = [];

--- a/src/portals/admin.js
+++ b/src/portals/admin.js
@@ -59,8 +59,10 @@ Admin.prototype.goDELETE = function (request, response) {
 
   if (id) {
     this.endpoints.delete(id, callback);
-  } else {
+  } else if (request.url === '/') {
     this.endpoints.deleteAll(callback);
+  } else {
+    this.notSupported(response);
   }
 };
 

--- a/src/portals/admin.js
+++ b/src/portals/admin.js
@@ -53,13 +53,15 @@ Admin.prototype.goDELETE = function (request, response) {
   var id = this.getId(request.url);
   var self = this;
 
-  if (!id) { return this.notSupported(response); }
-
   function callback (err) {
     if (err) { self.notFound(response); } else { self.noContent(response); }
   }
 
-  this.endpoints.delete(id, callback);
+  if (id) {
+    this.endpoints.delete(id, callback);
+  } else {
+    this.endpoints.deleteAll(callback);
+  }
 };
 
 Admin.prototype.goGET = function (request, response) {

--- a/test/admin.js
+++ b/test/admin.js
@@ -326,12 +326,25 @@ describe('Admin', function () {
     });
 
     describe('goDELETE', function () {
-      it('should delete all for the root url', function () {
+      it('should delete all stubs when calling from the root url', function () {
         this.sandbox.stub(sut, 'getId').returns('');
 
+        request.url = '/';
         sut.goDELETE(request, response);
 
         assert(endpoints.deleteAll.calledOnce);
+      });
+
+      ['/test', '/1/test'].forEach(function (url) {
+        it('should not delete all stubs when calling from non-root urls: ' + url, function () {
+          this.sandbox.stub(sut, 'getId').returns('');
+
+          request.url = url;
+          sut.goDELETE(request, response);
+
+          assert(endpoints.deleteAll.notCalled);
+          assert.strictEqual(response.statusCode, 405);
+        });
       });
 
       it('should delete item if id was gathered', function () {

--- a/test/admin.js
+++ b/test/admin.js
@@ -16,6 +16,7 @@ describe('Admin', function () {
       retrieve: this.sandbox.spy(),
       update: this.sandbox.spy(),
       delete: this.sandbox.spy(),
+      deleteAll: this.sandbox.spy(),
       gather: this.sandbox.spy()
     };
     sut = new Admin(endpoints, true);
@@ -325,13 +326,12 @@ describe('Admin', function () {
     });
 
     describe('goDELETE', function () {
-      it('should send not supported for the root url', function () {
+      it('should delete all for the root url', function () {
         this.sandbox.stub(sut, 'getId').returns('');
-        this.sandbox.spy(sut, 'notSupported');
 
         sut.goDELETE(request, response);
 
-        assert(sut.notSupported.calledOnce);
+        assert(endpoints.deleteAll.calledOnce);
       });
 
       it('should delete item if id was gathered', function () {

--- a/test/main.js
+++ b/test/main.js
@@ -99,6 +99,55 @@ describe('main', function () {
     });
   });
 
+  describe('delete', function () {
+    it('should call delete all when only a callback is passed', function (done) {
+      sut.endpoints = {
+        deleteAll: function (cb) {
+          cb(null);
+        }
+      };
+
+      sut.delete(function () {
+        done();
+      });
+    });
+
+    it('should call delete all when no params are passed', function (done) {
+      sut.endpoints = {
+        deleteAll: function () {
+          done();
+        }
+      };
+
+      sut.delete();
+    });
+
+    it('should call delete when an id is passed', function (done) {
+      sut.endpoints = {
+        delete: function (id, cb) {
+          assert.strictEqual(id, '1');
+          assert.strictEqual(cb, id);
+          done();
+        }
+      };
+
+      sut.delete('1');
+    });
+
+    it('should call delete when an id and callback are passed', function (done) {
+      sut.endpoints = {
+        delete: function (id, cb) {
+          assert.strictEqual(id, '1');
+          cb();
+        }
+      };
+
+      sut.delete('1', function () {
+        done();
+      });
+    });
+  });
+
   describe('start', function () {
     beforeEach(function () {
       options = {};


### PR DESCRIPTION
I've added a DELETE method on the root admin url eg. 

```
DELETE localhost:5000
```

This will delete all stubs. It's quite handy for something like functional testing where you are setting up / tearing down fixture data for each test. The alternative is having to maintain a list of IDs for every stub you create.