### PR TITLE
Try to compare with JSON Parser in HTTP POST

### DIFF
--- a/src/models/endpoint.js
+++ b/src/models/endpoint.js
@@ -41,7 +41,16 @@ class Endpoint {
     const post = file || this.request.post;
     if (post && request.post) {
       matches.post = matchRegex(normalizeEOL(post), normalizeEOL(request.post));
-      if (!matches.post) { return null; }
+      if (!matches.post) {
+        // Try to compare with JSON format
+        try {
+          const jsonRequest = JSON.parse(request.post);
+          const jsonPostRequest = JSON.parse(post);
+          if (!compareObjects(jsonRequest, jsonPostRequest)) { return null; }
+        } catch (e) {
+          return null;
+        }
+      }
     } else if (this.request.json && request.post) {
       try {
         json = JSON.parse(request.post);


### PR DESCRIPTION
### From my API requirement
my_api.yml
```
-  request:
      url: /demo
      method: POST
      headers:
         content-type: application/json
      file: input.json
   response:
    - status: 200
      body: "Haha!"
````

input.json
```
{"id": 1}
```

When i sent a POST request to mock api server with 
Payload in JSON format
```
{
    "id": 1
}
```

Result => Not match !! because data and indent not math or equal !!

## Solution :: I added logic in function match() to compare request.post and post with JSON parser



Welcome for feedback..

Thank you
